### PR TITLE
Load intel opencl driver by default and fix compiling issue in Android:

### DIFF
--- a/loader/linux/icd_linux.c
+++ b/loader/linux/icd_linux.c
@@ -38,6 +38,7 @@ static pthread_once_t initialized = PTHREAD_ONCE_INIT;
 // go through the list of vendors in the two configuration files
 void khrIcdOsVendorsEnumerate(void)
 {
+#ifndef __ANDROID__
     DIR *dir = NULL;
     struct dirent *dirEntry = NULL;
     char* vendorPath = ICD_VENDOR_PATH;
@@ -141,6 +142,8 @@ void khrIcdOsVendorsEnumerate(void)
     {
         khrIcd_free_getenv(envPath);
     }
+#endif
+    khrIcdVendorAdd("/vendor/lib64/libigdrcl.so");
 }
 
 // go through the list of vendors only once

--- a/loader/linux/icd_linux_envvars.c
+++ b/loader/linux/icd_linux_envvars.c
@@ -21,7 +21,9 @@
 #define _GNU_SOURCE
 #endif
 
+#ifndef __ANDROID__
 #include "icd_cmake_config.h"
+#endif
 
 #include <stdlib.h>
 


### PR DESCRIPTION
1, in Android, only one OpenCL driver is loaded, then it is unnecessary to load driver from icd file
2, fix compiling issue in Android to not include file  "icd_cmake_config.h".

Signed-off-by: dengliqiang <liqiangx.deng@intel.com>