### PR TITLE
Make the libOpenCL accessible to vendor domain.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -2,6 +2,9 @@ cc_defaults {
     name: "OpenCL-ICD-Loader-defaults",
 
     vendor_available: true,
+    vndk: {
+      enabled: true,
+    },
 
     cflags: [
         "-Wno-error",

--- a/bp/defaults.tpl
+++ b/bp/defaults.tpl
@@ -22,6 +22,9 @@ cc_defaults {
     name: "@name",
 
     vendor_available: true,
+    vndk: {
+      enabled: true,
+    },
 
     cflags: [
 @cflags

--- a/bp/icd-loader.tpl
+++ b/bp/icd-loader.tpl
@@ -23,6 +23,9 @@ cc_@module {
     name: "@name",
 
     vendor_available: true,
+    vndk: {
+      enabled: true,
+    },
 
     defaults: [
 @defaults

--- a/icd_loader_test.bp
+++ b/icd_loader_test.bp
@@ -2,6 +2,9 @@ cc_binary {
     name: "icd_loader_test",
 
     vendor_available: true,
+    vndk: {
+      enabled: true,
+    },
 
     defaults: [
         "OpenCL-ICD-Loader-defaults",

--- a/libIcdLog.bp
+++ b/libIcdLog.bp
@@ -2,6 +2,9 @@ cc_library_shared {
     name: "libIcdLog",
 
     vendor_available: true,
+    vndk: {
+      enabled: true,
+    },
 
     defaults: [
         "OpenCL-ICD-Loader-defaults",

--- a/libOpenCL.bp
+++ b/libOpenCL.bp
@@ -2,6 +2,9 @@ cc_library_shared {
     name: "libOpenCL",
 
     vendor_available: true,
+    vndk: {
+      enabled: true,
+    },
 
     defaults: [
         "OpenCL-ICD-Loader-defaults",

--- a/libOpenCLDriverStub.bp
+++ b/libOpenCLDriverStub.bp
@@ -3,6 +3,10 @@ cc_library_shared {
 
     vendor_available: true,
 
+    vndk: {
+      enabled: true,
+    },
+
     defaults: [
         "OpenCL-ICD-Loader-defaults",
     ],


### PR DESCRIPTION
Let libOpenCL relevant share libraries to be part of VNDK, so
that vendor domain could link it at runtime dynamically.

Change-Id: Ibc37f501b669d76b3f89e5f1ecbad15bbba433c8
Tracked-On: OAM-92070
Signed-off-by: Wan Shuang <shuang.wan@intel.com>