### PR TITLE
Make the libOpenCL accessible to vendor domain only.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,7 +1,7 @@
 cc_defaults {
     name: "OpenCL-ICD-Loader-defaults",
 
-    vendor_available: true,
+    vendor: true,
 
     cflags: [
         "-Wno-error",

--- a/bp/defaults.tpl
+++ b/bp/defaults.tpl
@@ -21,7 +21,7 @@
 cc_defaults {
     name: "@name",
 
-    vendor_available: true,
+    vendor: true,
 
     cflags: [
 @cflags

--- a/bp/icd-loader.tpl
+++ b/bp/icd-loader.tpl
@@ -22,7 +22,7 @@
 cc_@module {
     name: "@name",
 
-    vendor_available: true,
+    vendor: true,
 
     defaults: [
 @defaults

--- a/icd_loader_test.bp
+++ b/icd_loader_test.bp
@@ -1,7 +1,7 @@
 cc_binary {
     name: "icd_loader_test",
 
-    vendor_available: true,
+    vendor: true,
 
     defaults: [
         "OpenCL-ICD-Loader-defaults",

--- a/libIcdLog.bp
+++ b/libIcdLog.bp
@@ -1,7 +1,7 @@
 cc_library_shared {
     name: "libIcdLog",
 
-    vendor_available: true,
+    vendor: true,
 
     defaults: [
         "OpenCL-ICD-Loader-defaults",

--- a/libOpenCL.bp
+++ b/libOpenCL.bp
@@ -1,7 +1,7 @@
 cc_library_shared {
     name: "libOpenCL",
 
-    vendor_available: true,
+    vendor: true,
 
     defaults: [
         "OpenCL-ICD-Loader-defaults",

--- a/libOpenCLDriverStub.bp
+++ b/libOpenCLDriverStub.bp
@@ -1,7 +1,7 @@
 cc_library_shared {
     name: "libOpenCLDriverStub",
 
-    vendor_available: true,
+    vendor: true,
 
     defaults: [
         "OpenCL-ICD-Loader-defaults",


### PR DESCRIPTION
Ensure vendor domain could access the openCL share libraries at
runtime.

Change-Id: I7e351d98832e74bb4164a3cad863334b95b53732
Tracked-On: OAM-92070
Signed-off-by: Wan Shuang <shuang.wan@intel.com>