### PR TITLE
Remove vndk mode for openCL libraries.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,10 +1,7 @@
 cc_defaults {
     name: "OpenCL-ICD-Loader-defaults",
 
-    vendor_available: true,
-    vndk: {
-      enabled: true,
-    },
+    vendor: true,
 
     cflags: [
         "-Wno-error",

--- a/bp/defaults.tpl
+++ b/bp/defaults.tpl
@@ -21,10 +21,7 @@
 cc_defaults {
     name: "@name",
 
-    vendor_available: true,
-    vndk: {
-      enabled: true,
-    },
+    vendor: true,
 
     cflags: [
 @cflags

--- a/bp/icd-loader.tpl
+++ b/bp/icd-loader.tpl
@@ -22,10 +22,7 @@
 cc_@module {
     name: "@name",
 
-    vendor_available: true,
-    vndk: {
-      enabled: true,
-    },
+    vendor: true,
 
     defaults: [
 @defaults

--- a/icd_loader_test.bp
+++ b/icd_loader_test.bp
@@ -1,10 +1,7 @@
 cc_binary {
     name: "icd_loader_test",
 
-    vendor_available: true,
-    vndk: {
-      enabled: true,
-    },
+    vendor: true,
 
     defaults: [
         "OpenCL-ICD-Loader-defaults",

--- a/libIcdLog.bp
+++ b/libIcdLog.bp
@@ -1,10 +1,7 @@
 cc_library_shared {
     name: "libIcdLog",
 
-    vendor_available: true,
-    vndk: {
-      enabled: true,
-    },
+    vendor: true,
 
     defaults: [
         "OpenCL-ICD-Loader-defaults",

--- a/libOpenCL.bp
+++ b/libOpenCL.bp
@@ -1,10 +1,7 @@
 cc_library_shared {
     name: "libOpenCL",
 
-    vendor_available: true,
-    vndk: {
-      enabled: true,
-    },
+    vendor: true,
 
     defaults: [
         "OpenCL-ICD-Loader-defaults",

--- a/libOpenCLDriverStub.bp
+++ b/libOpenCLDriverStub.bp
@@ -1,11 +1,7 @@
 cc_library_shared {
     name: "libOpenCLDriverStub",
 
-    vendor_available: true,
-
-    vndk: {
-      enabled: true,
-    },
+    vendor: true,
 
     defaults: [
         "OpenCL-ICD-Loader-defaults",


### PR DESCRIPTION
VNDK mode breaks the API locked branches, so remove the vndk mode.

Change-Id: Id4e7cc1241b08b82dea3d655f15a278673df68ae
Tracked-On: OAM-92270
Signed-off-by: Wan Shuang <shuang.wan@intel.com>